### PR TITLE
change log file path to external storage

### DIFF
--- a/app/src/main/java/com/github/kr328/clash/util/Files.kt
+++ b/app/src/main/java/com/github/kr328/clash/util/Files.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import java.io.File
 
 val Context.logsDir: File
-    get() = cacheDir.resolve("logs")
+    get() = getExternalFilesDir(null)?.resolve("logs") ?: cacheDir.resolve("logs")
 
 val Context.clashDir: File
     get() = filesDir.resolve("clash")


### PR DESCRIPTION
Change log file save path to external directory.

* Modify `logsDir` property in `app/src/main/java/com/github/kr328/clash/util/Files.kt` to point to an external directory for saving log files.
* Use `getExternalFilesDir(null)?.resolve("logs")` to get the external directory, and fallback to `cacheDir.resolve("logs")` if the external directory is not available.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/p0we7/ClashMetaForAndroid/pull/1?shareId=d66b96bf-b3cc-4920-9a3e-01fe38bfa408).